### PR TITLE
chore(langchain): rename chat model

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ await model.call('Tell me a joke.', undefined, [
 import { GenAIChatModel } from '@ibm-generative-ai/node-sdk/langchain';
 
 const client = new GenAIChatModel({
-  modelId: 'sambanovasystems/bloomchat-176b-v1',
+  modelId: 'togethercomputer/gpt-neoxt-chat-base-20b',
   stream: false,
   configuration: {
     endpoint: process.env.ENDPOINT,

--- a/examples/langchain/llm-chat.ts
+++ b/examples/langchain/llm-chat.ts
@@ -3,7 +3,7 @@ import { HumanChatMessage } from 'langchain/schema';
 
 const makeClient = (stream?: boolean) =>
   new GenAIChatModel({
-    modelId: 'sambanovasystems/bloomchat-176b-v1',
+    modelId: 'togethercomputer/gpt-neoxt-chat-base-20b',
     stream,
     configuration: {
       endpoint: process.env.ENDPOINT,

--- a/src/tests/e2e/langchain/llm-chat.test.ts
+++ b/src/tests/e2e/langchain/llm-chat.test.ts
@@ -8,7 +8,7 @@ describeIf(process.env.RUN_LANGCHAIN_CHAT_TESTS === 'true')(
   () => {
     const makeClient = (stream?: boolean) =>
       new GenAIChatModel({
-        modelId: 'sambanovasystems/bloomchat-176b-v1',
+        modelId: 'togethercomputer/gpt-neoxt-chat-base-20b',
         stream,
         configuration: {
           endpoint: process.env.ENDPOINT,


### PR DESCRIPTION
The `sambanovasystems/bloomchat-176b-v1` chat model no longer exists in our stack. Switching to a different one.