### PR TITLE
feat(history): update history schema

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -92,11 +92,13 @@ export const GenerateResultSchema = z
   .passthrough();
 export type GenerateResult = z.infer<typeof GenerateResultSchema>;
 
-export const GenerateOutputSchema = z.object({
-  model_id: z.string(),
-  created_at: z.coerce.date(),
-  results: z.array(GenerateResultSchema),
-});
+export const GenerateOutputSchema = z
+  .object({
+    model_id: z.string(),
+    created_at: z.coerce.date(),
+    results: z.array(GenerateResultSchema),
+  })
+  .passthrough();
 export type GenerateOutput = z.infer<typeof GenerateOutputSchema>;
 
 export const GenerateLimitsOutputSchema = z.object({
@@ -350,14 +352,16 @@ export type HistoryInput = z.input<typeof HistoryInputSchema>;
 
 export const HistoryOutputSchema = PaginationOutputSchema.extend({
   results: z.array(
-    z.object({
-      id: z.string(),
-      duration: z.number().int().min(0),
-      request: GenerateInputSchema.partial(),
-      status: HistoryInputSchema.shape.status,
-      created_at: z.coerce.date(),
-      response: GenerateOutputSchema,
-    }),
+    z
+      .object({
+        id: z.string(),
+        duration: z.number().int().min(0),
+        request: GenerateInputSchema.partial(),
+        status: HistoryInputSchema.shape.status,
+        created_at: z.coerce.date(),
+        response: GenerateOutputSchema.nullable(),
+      })
+      .passthrough(),
   ),
 });
 export type HistoryOutput = z.infer<typeof HistoryOutputSchema>;

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -224,6 +224,12 @@ export const HistoryOutputSchema =
   ApiTypes.HistoryOutputSchema.shape.results.element;
 export type HistoryOutput = z.infer<typeof HistoryOutputSchema>;
 
+export const HistoryStatusSchema = ApiTypes.HistoryStatusSchema;
+export type HistoryStatus = z.infer<typeof HistoryStatusSchema>;
+
+export const HistoryOriginSchema = ApiTypes.HistoryOriginSchema;
+export type HistoryOrigin = z.infer<typeof HistoryOriginSchema>;
+
 // FILES
 
 export const FilePurposeSchema = ApiTypes.FilePurposeSchema;


### PR DESCRIPTION
- Export missing history related types.
- In case the status is equal to `ERROR`, the `response` property is `null`.