### PR TITLE
fix: handle streaming errors

### DIFF
--- a/src/api/streaming-client.ts
+++ b/src/api/streaming-client.ts
@@ -107,6 +107,10 @@ export function createStreamingApiClient(clientOptions: {
             );
             return;
           }
+          if (message.event === 'error') {
+            onError(new HttpError(result));
+            return;
+          }
 
           outputStream.push(result);
         },


### PR DESCRIPTION
An error can occur in the middle of a stream. This PR handles such cases.